### PR TITLE
Make things work again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.flatpak-builder/
 build/*

--- a/README.md
+++ b/README.md
@@ -7,11 +7,10 @@ See the current temperature and weather conditions for your location with this m
 
 ## Building, Testing, and Installation
 
-
 You'll need the following dependencies to build:
 * libgeoclue-2-dev
 * libgtk-3-dev
-* libgweather-3-dev
+* libgweather-4-dev
 * libhandy-1-dev
 * meson
 * valac

--- a/com.github.danrabbit.nimbus.yml
+++ b/com.github.danrabbit.nimbus.yml
@@ -8,7 +8,6 @@ finish-args:
   - '--socket=fallback-x11'
   - '--socket=wayland'
   - '--share=network'
-  - '--system-talk-name=org.freedesktop.GeoClue2'
 
   - '--metadata=X-DConf=migrate-path=/com/github/danrabbit/nimbus/'
 modules:

--- a/com.github.danrabbit.nimbus.yml
+++ b/com.github.danrabbit.nimbus.yml
@@ -1,6 +1,6 @@
 app-id: com.github.danrabbit.nimbus
 runtime: io.elementary.Platform
-runtime-version: 'daily'
+runtime-version: '7.2'
 sdk: io.elementary.Sdk
 command: com.github.danrabbit.nimbus
 finish-args:
@@ -16,20 +16,22 @@ modules:
     config-opts:
       - '-Denable-installed-tests=false'
       - '-Denable-gtk-doc=false'
+      - '-Dsoup2=false'
     buildsystem: meson
     sources:
-      - type: git
-        url: https://gitlab.gnome.org/GNOME/geocode-glib.git
-        tag: '3.26.2'
+      - type: archive
+        url: https://download.gnome.org/sources/geocode-glib/3.26/geocode-glib-3.26.4.tar.xz
+        sha256: 2d9a6826d158470449a173871221596da0f83ebdcff98b90c7049089056a37aa
 
   - name: gweather
     config-opts:
       - '-Dgtk_doc=false'
+      - '-Dtests=false'
     buildsystem: meson
     sources:
-      - type: git
-        url: https://gitlab.gnome.org/GNOME/libgweather.git
-        tag: '40.0'
+      - type: archive
+        url: https://download.gnome.org/sources/libgweather/4.2/libgweather-4.2.0.tar.xz
+        sha256: af8a812da0d8976a000e1d62572c256086a817323fbf35b066dbfdd8d2ca6203
 
   - name: nimbus
     buildsystem: meson

--- a/meson.build
+++ b/meson.build
@@ -13,7 +13,7 @@ asresources = gnome.compile_resources(
     c_name: 'as'
 )
 
-gweather_dep = dependency('gweather-3.0')
+gweather_dep = dependency('gweather4')
 
 c_args = [
   '-DGWEATHER_I_KNOW_THIS_IS_UNSTABLE',

--- a/meson.build
+++ b/meson.build
@@ -13,8 +13,6 @@ asresources = gnome.compile_resources(
     c_name: 'as'
 )
 
-gweather_dep = dependency('gweather4')
-
 executable(
     meson.project_name(),
     'src/Application.vala',
@@ -24,7 +22,7 @@ executable(
         dependency('glib-2.0'),
         dependency('gobject-2.0'),
         dependency('gtk+-3.0'),
-        gweather_dep,
+        dependency('gweather4'),
         dependency('libgeoclue-2.0'),
         dependency('libhandy-1')
     ],

--- a/meson.build
+++ b/meson.build
@@ -15,16 +15,11 @@ asresources = gnome.compile_resources(
 
 gweather_dep = dependency('gweather4')
 
-c_args = [
-  '-DGWEATHER_I_KNOW_THIS_IS_UNSTABLE',
-]
-
 executable(
-    'com.github.danrabbit.nimbus',
+    meson.project_name(),
     'src/Application.vala',
     'src/MainWindow.vala',
     asresources,
-    c_args: c_args,
     dependencies: [
         dependency('glib-2.0'),
         dependency('gobject-2.0'),

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -49,7 +49,7 @@ public class MainWindow : Hdy.ApplicationWindow {
         get_location.begin ();
 
         weather_info = new GWeather.Info (location) {
-            contact_info = "daniel@elementary.io"
+            contact_info = "danielle@elementary.io"
         };
 
         var weather_icon = new Gtk.Image.from_icon_name (weather_info.get_symbolic_icon_name (), Gtk.IconSize.DIALOG);

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -48,7 +48,9 @@ public class MainWindow : Hdy.ApplicationWindow {
 
         get_location.begin ();
 
-        weather_info = new GWeather.Info (location);
+        weather_info = new GWeather.Info (location) {
+            contact_info = "daniel@elementary.io"
+        };
 
         var weather_icon = new Gtk.Image.from_icon_name (weather_info.get_symbolic_icon_name (), Gtk.IconSize.DIALOG);
 


### PR DESCRIPTION
Looks like the current code base is a little old and it' failing to fetch weather info. This PR fixes it.
I really like this cute app, so would like to see it in AppCenter again if possible :)

## Changes summary
- Update Flatpak manifest
  - Update runtime version and dependencies
  - Use tarballs instead of git for (a little) faster process
- Address API changes in libgweather
  - Remove `GWEATHER_I_KNOW_THIS_IS_UNSTABLE` flag (it's dropped, see [libgweather@de55bfd7](https://gitlab.gnome.org/GNOME/libgweather/-/commit/de55bfd77406744a4dddd025af826870d7810dea))
  - Set contact info (this looks like necessary since 40, see the following links:
    - [gnome-calendar@a2a6d2e4](https://gitlab.gnome.org/GNOME/gnome-calendar/-/commit/a2a6d2e4aafc3bed082a3d21e2c470492ef468b1)
    - [gnome-weather@6763f7dc](https://gitlab.gnome.org/GNOME/gnome-weather/-/commit/6763f7dc9cb25eac4aa13e94e07ea932a42c8e4d)
    - [libgweather#59](https://gitlab.gnome.org/GNOME/libgweather/-/issues/59)
    - I used your email address used in the commit history here, I'm sorry if you mind it.

## Confirmed things
- [x] Confirmed that it builds with no warnings/errors
- [x] Confirmed that the app runs and weather shown depending on the current location

## How to test this branch
The app fails to get location in Flatpak installation (because of the same reason in https://github.com/elementary/default-settings/issues/278). So run `gsettings set org.gnome.system.location enabled true` before running this branch for the first time.